### PR TITLE
Prepare complete native functionality

### DIFF
--- a/packages/sapling-android/app/src/main/cpp/sapling.cpp
+++ b/packages/sapling-android/app/src/main/cpp/sapling.cpp
@@ -430,7 +430,7 @@ Java_it_airgap_sapling_Sapling_extPaymentAddressFromIvk(
     const unsigned char *div = jbyteArray_to_uchar(env, jdiv, &div_len);
 
     size_t addr_len;
-    unsigned char *addr = c_payment_address_from_xfvk(ivk, ivk_len, div, div_len, &addr_len);
+    unsigned char *addr = c_payment_address_from_ivk(ivk, ivk_len, div, div_len, &addr_len);
     jbyteArray jaddr = uchar_to_jbyteArray(env, addr, addr_len);
 
     local_clean(ivk);
@@ -469,7 +469,7 @@ Java_it_airgap_sapling_Sapling_extPkdFromPaymentAddress(
     const unsigned char *addr = jbyteArray_to_uchar(env, jaddr, &addr_len);
 
     size_t pkd_len;
-    unsigned char *pkd = c_diversifier_from_payment_address(addr, addr_len, &pkd_len);
+    unsigned char *pkd = c_pkd_from_payment_address(addr, addr_len, &pkd_len);
     jbyteArray jpkd = uchar_to_jbyteArray(env, pkd, pkd_len);
 
     local_clean(addr);
@@ -733,6 +733,7 @@ Java_it_airgap_sapling_Sapling_extXsk(
     unsigned char *xsk = c_xsk(seed, seed_len, d_path, &xsk_len);
     jbyteArray jxsk = uchar_to_jbyteArray(env, xsk, xsk_len);
 
+    env->ReleaseStringUTFChars(jd_path, d_path);
     local_clean(seed);
     ffi_clean(xsk);
 
@@ -757,6 +758,7 @@ Java_it_airgap_sapling_Sapling_extXfvk(
     unsigned char *xfvk = c_xfvk(seed, seed_len, d_path, &xfvk_len);
     jbyteArray jxfvk = uchar_to_jbyteArray(env, xfvk, xfvk_len);
 
+    env->ReleaseStringUTFChars(jd_path, d_path);
     local_clean(seed);
     ffi_clean(xfvk);
 
@@ -789,7 +791,7 @@ Java_it_airgap_sapling_Sapling_extOvkFromXfvk(JNIEnv *env, jobject /* this */, j
     const unsigned char *xfvk = jbyteArray_to_uchar(env, jxfvk, &xfvk_len);
 
     size_t ovk_len;
-    unsigned char *ovk = c_xfvk_from_xsk(xfvk, xfvk_len, &ovk_len);
+    unsigned char *ovk = c_ovk_from_xfvk(xfvk, xfvk_len, &ovk_len);
     jbyteArray jovk = uchar_to_jbyteArray(env, ovk, ovk_len);
 
     local_clean(xfvk);

--- a/packages/sapling-android/app/src/main/cpp/utils.cpp
+++ b/packages/sapling-android/app/src/main/cpp/utils.cpp
@@ -23,7 +23,7 @@ jbyteArray uchar_to_jbyteArray(JNIEnv *env, unsigned char *uchar_arr, size_t uch
 }
 
 void local_clean(const unsigned char *arr) {
-    delete arr;
+    delete[] arr;
 }
 
 void ffi_clean(unsigned char *arr) {

--- a/packages/sapling-android/app/src/main/java/it/airgap/sapling/Sapling.kt
+++ b/packages/sapling-android/app/src/main/java/it/airgap/sapling/Sapling.kt
@@ -71,6 +71,10 @@ public class Sapling {
     public fun preparePartialOutputDescription(context: Long, address: ByteArray, rcm: ByteArray, esk: ByteArray, value: Long): ByteArray =
         extPartialOutputDescription(context, address, rcm, esk, value) ?: throw SaplingException("Failed to prepare output description")
 
+    @Throws(SaplingException::class)
+    public fun deriveEpkFromEsk(diversifier: ByteArray, esk: ByteArray): ByteArray =
+        extDeriveEpkFromEsk(diversifier, esk) ?: throw SaplingException("Failed to derive epk from esk")
+
     private external fun extOutputDescriptionFromXfvk(
         context: Long,
         xfvk: ByteArray,

--- a/packages/sapling-ios/Sources/Sapling/Sapling.swift
+++ b/packages/sapling-ios/Sources/Sapling/Sapling.swift
@@ -113,6 +113,15 @@ public struct Sapling {
         return description
     }
 
+    public func deriveEpkFromEsk(with diversifier: Diversifier, withEsk esk: Esk) throws -> [UInt8] {
+        var epkCount = 0
+        guard let epk = c_derive_epk_from_esk(diversifier, diversifier.count, esk, esk.count, &epkCount)?.toArray(count: epkCount) else {
+            throw Error.deriveKeyFailed
+        }
+
+        return epk
+    }
+
     // MARK: Payment Address
 
     public func getPaymentAddress(from viewingKey: ExtendedFullViewingKey, at index: Index) throws -> [UInt8] {


### PR DESCRIPTION
What has changed:
- Fixed spontaneous crashes for Android 16 by fixing the clearing of local buffers
- Fixed JNI bindings that used inappropriate functions from Rust crates
- Exposed `deriveEpkFromEsk` function to ensure that a React Native application does not need a WebView to implement sapling transactions